### PR TITLE
Add background in storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,5 +4,6 @@ module.exports = {
 		'@storybook/preset-create-react-app',
 		'@storybook/addon-docs',
 		'@storybook/addon-links',
+		'@storybook/addon-backgrounds',
 	],
 };

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,0 +1,15 @@
+export const parameters = {
+	backgrounds: {
+		default: 'light',
+		values: [
+			{
+				name: 'light',
+				value: '#fafafa',
+			},
+			{
+				name: 'dark',
+				value: '#303030',
+			},
+		],
+	},
+};

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react": "^16.0.0"
   },
   "devDependencies": {
+    "@storybook/addon-backgrounds": "^6.0.19",
     "@storybook/addon-docs": "^6.0.12",
     "@storybook/addon-links": "^6.0.12",
     "@storybook/addons": "^6.0.12",


### PR DESCRIPTION
The current white background makes it hard to see the (white) cards. This commit adds a default gray background. It also adds the storybook addon to easily change the background to dark mode.